### PR TITLE
Restore zsh history sharing and retention

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -3,6 +3,16 @@
 # Typing a directory path (e.g. ../foo) auto-cds into it
 setopt AUTO_CD
 
+# History
+HISTSIZE=50000
+SAVEHIST=10000
+setopt EXTENDED_HISTORY
+setopt INC_APPEND_HISTORY
+setopt SHARE_HISTORY
+setopt HIST_IGNORE_DUPS
+setopt HIST_IGNORE_SPACE
+setopt HIST_VERIFY
+
 # Resolve Homebrew prefix: read from disk cache, or resolve once and cache
 _brew_cache="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/homebrew_prefix"
 if [[ -r "$_brew_cache" ]]; then


### PR DESCRIPTION
## Summary

- Re-adds the history `setopt`s and sizes that oh-my-zsh's `lib/history.zsh` used to set.
- Fixes the symptom where a command run in one terminal can't be found via Ctrl-R in another until the originating shell exits.

## Background

Antigen was removed in 9dd9578. Antigen pulled in oh-my-zsh's `lib/history.zsh`, which set:

- `HISTSIZE=50000`, `SAVEHIST=10000`
- `SHARE_HISTORY` (cross-session visibility) and `INC_APPEND_HISTORY` (write each command immediately)
- `EXTENDED_HISTORY`, `HIST_IGNORE_DUPS`, `HIST_IGNORE_SPACE`, `HIST_VERIFY`

Without these, history wasn't being shared across sessions and retention had quietly dropped to whatever zsh's fallback produced (2000 / 1000 on this machine).

## Test plan

- [x] `zsh -c 'source zshrc; echo $HISTSIZE $SAVEHIST; setopt | grep -iE "hist|share"'` shows `50000 10000` and all 7 setopts active.
- [ ] Open a new terminal after merge and confirm Ctrl-R surfaces commands typed in another tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)