### PR TITLE
Tighten PR-description and test-runner rules

### DIFF
--- a/agents/rules/closing-the-loop.md
+++ b/agents/rules/closing-the-loop.md
@@ -26,19 +26,12 @@ The first meaningful failure tells me whether the dependency surface is sane.
 ### Use the project's task runner, not the underlying tool
 
 When the repo wraps its build/test commands in a fastlane lane, a `Makefile` target, a `rake` task, or an npm/yarn script, **invoke the wrapper, not the underlying tool**.
+Example: `bundle exec fastlane test` over `xcodebuild test -workspace <workspace> -scheme <scheme>`.
 
-- iOS: `bundle exec fastlane test` over `xcodebuild test -workspace … -scheme …`.
-- Ruby: `bundle exec rake test` over `bundle exec ruby -Itest test/foo.rb`.
-- C/C++: `make test` over hand-rolled `gcc`/`cmake` invocations.
-- Node: `yarn test` or `npm test` over a raw `jest`/`vitest` call.
-
-The wrapper encodes setup the underlying tool doesn't know about: env vars, build configurations, simulator/device selection, test filtering, retry behavior, code-coverage flags, output formatting CI consumes.
-Bypassing it gets a different result than CI will, and reviewers who try to reproduce the test step using the recommended command will fail.
+The wrapper encodes setup the underlying tool doesn't know about, bypassing it risks getting a different result that the golden path.
 
 Discover the runner before improvising: check `fastlane/Fastfile`, `Makefile`, `Rakefile`, `package.json` scripts, `README` "How to test" / "Development" sections.
 If none exists and the tool requires non-trivial flags to invoke correctly, surface that as a finding — adding a one-liner wrapper is usually a small change worth proposing — rather than recommending the raw command to the user.
-
-This rule applies symmetrically to PR descriptions: see the "How to test" guidance in [`github.md`](github.md).
 
 ## Tier 3 — push and watch
 

--- a/agents/rules/closing-the-loop.md
+++ b/agents/rules/closing-the-loop.md
@@ -23,6 +23,23 @@ The first meaningful failure tells me whether the dependency surface is sane.
 - Build script: invoke with the env vars CI would set.
 - Type checks, linters, unit tests for touched files.
 
+### Use the project's task runner, not the underlying tool
+
+When the repo wraps its build/test commands in a fastlane lane, a `Makefile` target, a `rake` task, or an npm/yarn script, **invoke the wrapper, not the underlying tool**.
+
+- iOS: `bundle exec fastlane test` over `xcodebuild test -workspace … -scheme …`.
+- Ruby: `bundle exec rake test` over `bundle exec ruby -Itest test/foo.rb`.
+- C/C++: `make test` over hand-rolled `gcc`/`cmake` invocations.
+- Node: `yarn test` or `npm test` over a raw `jest`/`vitest` call.
+
+The wrapper encodes setup the underlying tool doesn't know about: env vars, build configurations, simulator/device selection, test filtering, retry behavior, code-coverage flags, output formatting CI consumes.
+Bypassing it gets a different result than CI will, and reviewers who try to reproduce the test step using the recommended command will fail.
+
+Discover the runner before improvising: check `fastlane/Fastfile`, `Makefile`, `Rakefile`, `package.json` scripts, `README` "How to test" / "Development" sections.
+If none exists and the tool requires non-trivial flags to invoke correctly, surface that as a finding — adding a one-liner wrapper is usually a small change worth proposing — rather than recommending the raw command to the user.
+
+This rule applies symmetrically to PR descriptions: see the "How to test" guidance in [`github.md`](github.md).
+
 ## Tier 3 — push and watch
 
 No faithful local equivalent; faking one wastes more time than a CI iteration.

--- a/agents/rules/github.md
+++ b/agents/rules/github.md
@@ -32,13 +32,12 @@ Otherwise, a PR description should cover:
 
 **Length target: the whole description fits on one screen.**
 Each section is 1–3 sentences, not paragraphs.
-If a section has nothing important to say, omit it — don't pad with throat-clearing.
+If a section has nothing important to say, omit it.
 Bullets are fine when listing distinct items; prose is fine when explaining one thing. Pick one, don't mix.
 Cut every sentence that doesn't change a reviewer's understanding.
 When in doubt, default to terser.
 
-**Do not explain the implementation** — the diff shows it.
-Phrases like "the change works by …", "this PR introduces a helper that …", "we then iterate over …" describe code the reviewer can read.
+**Do not explain the implementation**.
 Describe the *why* and the *constraints*, not the *how*.
 
 **Do not pre-empt every possible reviewer question.**
@@ -59,6 +58,4 @@ Without a link, drop the reference and explain the technical point directly.
 
 **"How to test" — recommend the project's task runner, not the underlying tool.**
 If the repo has a fastlane lane, a `Makefile` target, a `rake` task, or an npm script that runs the relevant test/build, that is the command to write in the PR.
-Do not recommend `xcodebuild test …` when `bundle exec fastlane test` exists; do not recommend a raw `jest` invocation when `yarn test` is wired up.
-The wrapper encodes the project's expected env, build config, simulator selection, and test filter — bypassing it gives the reviewer (and CI) a different result than the author got.
-Same rule applies to commands you run yourself while preparing the PR — see [`closing-the-loop.md`](closing-the-loop.md) for the local verification rationale.
+For example, do not recommend `xcodebuild test` when `bundle exec fastlane test` exists; do not recommend a raw `jest` invocation when `yarn test` is wired up.

--- a/agents/rules/github.md
+++ b/agents/rules/github.md
@@ -30,6 +30,21 @@ Otherwise, a PR description should cover:
 - **Gotchas** — anything a reviewer or future reader needs to know that the diff alone won't tell them.
 - **How to test** — concrete steps or links to CI runs.
 
+**Length target: the whole description fits on one screen.**
+Each section is 1–3 sentences, not paragraphs.
+If a section has nothing important to say, omit it — don't pad with throat-clearing.
+Bullets are fine when listing distinct items; prose is fine when explaining one thing. Pick one, don't mix.
+Cut every sentence that doesn't change a reviewer's understanding.
+When in doubt, default to terser.
+
+**Do not explain the implementation** — the diff shows it.
+Phrases like "the change works by …", "this PR introduces a helper that …", "we then iterate over …" describe code the reviewer can read.
+Describe the *why* and the *constraints*, not the *how*.
+
+**Do not pre-empt every possible reviewer question.**
+Anticipatory paragraphs ("you might wonder why we …", "note that this does not …") are noise unless the concern is genuinely non-obvious.
+Trust the reviewer to ask if they care.
+
 Do **not** include a "change list" or file-by-file enumeration.
 The diff already shows what changed; reviewers are smart enough to read it as long as the PR is small.
 If the PR is not small, list the changes at the architecture overview only, as a guide to navigate the review.
@@ -41,3 +56,9 @@ Do not require reviewers to have context about adjacent or sibling projects.
 If a sentence only makes sense to someone who knows another repo's setup, rewrite it so the point stands on its own.
 Cross-project references are fine when they motivate the change, but only with a link the reviewer can follow.
 Without a link, drop the reference and explain the technical point directly.
+
+**"How to test" — recommend the project's task runner, not the underlying tool.**
+If the repo has a fastlane lane, a `Makefile` target, a `rake` task, or an npm script that runs the relevant test/build, that is the command to write in the PR.
+Do not recommend `xcodebuild test …` when `bundle exec fastlane test` exists; do not recommend a raw `jest` invocation when `yarn test` is wired up.
+The wrapper encodes the project's expected env, build config, simulator selection, and test filter — bypassing it gives the reviewer (and CI) a different result than the author got.
+Same rule applies to commands you run yourself while preparing the PR — see [`closing-the-loop.md`](closing-the-loop.md) for the local verification rationale.


### PR DESCRIPTION
## Rationale

Two recurring failures despite the existing rules:

- PR descriptions kept drifting verbose — the "keep them lean" rule wasn't aggressive enough.
- Recommended raw `xcodebuild test …` in "How to test" sections when a fastlane lane wrapped it.

`github.md` gains a one-screen length target, named anti-patterns (explaining implementation, pre-empting questions), and a "use the project's task runner" rule for "How to test".
`closing-the-loop.md` gains the same runner-not-tool rule for local Tier 2 verification so the PR-side and local-side guidance stay symmetric.

## Gotchas

Rules take effect on `git pull` — `~/.config/agents/rules/` already symlinks at this repo, no setup re-run needed.