### PR TITLE
Harden typo-sweep apply-fix with drift + quote guards

### DIFF
--- a/agents/skills/typo-sweep/SKILL.md
+++ b/agents/skills/typo-sweep/SKILL.md
@@ -22,8 +22,11 @@ If empty, ask the user via `AskUserQuestion`.
 
 - `typos.txt` — curated misspelling → correction list.
 - `scan.sh` — ripgrep wrapper that scans a directory using `typos.txt`.
-- `apply-fix.py` — line-by-line word-boundary substitution.
-  Refuses to substitute when the word isn't present on the given line, so misalignments fail loudly.
+- `apply-fix.py` — word-boundary substitution with two guards:
+  - **Content match (drift-safe):** pass the scan's matched line text as a 5th arg and the fix lands on the line with that content wherever it moved, skipping (loudly) a line that changed or was already fixed upstream — never guessing.
+  - **Single-quote guard:** refuses an apostrophe correction (`don't`, `today's`, …) that would land inside a single-quoted string literal (`it '...'`, `it('...')`) and break it. Comments and double-quoted strings proceed.
+  - Still refuses when the word isn't present, so misalignments fail loudly.
+  - `test_apply_fix.py` pins these behaviors: `python3 test_apply_fix.py`.
 
 Reference them via `$(dirname "$0")` inside scripts, or via the absolute paths under `~/.claude/skills/typo-sweep/` (or `~/.dotfiles/agents/skills/typo-sweep/`).
 
@@ -103,14 +106,18 @@ Output is `path:line:col:matched line` per finding.
 - `happend` → "happen" or "happened" depending on tense. "Should never happend" wants `happen`, not `happened`.
 - `zeroes` is a valid English plural and a verb — leave it alone.
 - `doesnt` in a Kotlin backticked test name fixes to `doesn't` (apostrophe inside backticks is fine), but verify the rename doesn't break a golden filename or CI test filter.
+- **Apostrophe into a single-quoted string breaks code.** `dont`/`doesnt`/`todays` → `don't`/`doesn't`/`today's` inside a single-quoted Ruby/JS string (RSpec `it '...'`, JS `it('...')`) terminates the string. `apply-fix.py` refuses these, but prefer not to queue them. Comments and double-quoted strings are safe.
+- **Lint runs on changed files.** A comment fix pulls its file into the PR's changed set, surfacing pre-existing lint debt (e.g. TS typecheck, detekt), and adding a char (`today's`) can push a backtick test name past a line-length limit. If CI flags a file you only touched a comment in, drop that file/line from the PR rather than fixing unrelated debt.
 
 When unsure, skip the fix.
 
 #### e. Apply fixes — cap at ~50 substitutions per PR
 
 ```
-python3 $SKILL_DIR/apply-fix.py <worktree>/<file> <line> <old> <new>
+python3 $SKILL_DIR/apply-fix.py <worktree>/<file> <line> <old> <new> "<matched line text>"
 ```
+
+Pass the scan's matched line text (the part after `path:line:col:` in the `scan.sh` output) as the 5th arg. This makes the fix drift-safe — it lands on the line with that content even if line numbers shifted, and skips loudly if the line changed or was already fixed upstream. The 4-arg form (no matched line) still works but addresses by line number only.
 
 After each substitution count, stop adding more fixes for this PR once you hit **50 substitutions** (≈ 50 changed file lines / ≈ 100 diff lines).
 A small follow-up sweep can pick up the remainder later.

--- a/agents/skills/typo-sweep/apply-fix.py
+++ b/agents/skills/typo-sweep/apply-fix.py
@@ -81,12 +81,31 @@ match = pattern.search(line)
 # --- Single-quote guard -------------------------------------------------------
 if "'" in new:
     in_single = in_double = False
-    for ch in line[:match.start()]:
+    escaped = False
+    in_comment = False
+    i = 0
+    while i < match.start():
+        ch = line[i]
+        if in_comment:
+            break
+        if escaped:
+            escaped = False
+            i += 1
+            continue
+        if ch == "\\":
+            escaped = True
+            i += 1
+            continue
+        if not in_single and not in_double:
+            if line.startswith("//", i) or line.startswith("#", i):
+                in_comment = True
+                break
         if ch == "'" and not in_double:
             in_single = not in_single
         elif ch == '"' and not in_single:
             in_double = not in_double
-    if in_single:
+        i += 1
+    if in_single and not in_comment:
         print(f"SKIP(single-quote) {path}:{idx + 1} '{old}->{new}' sits inside a "
               f"single-quoted string; apostrophe would break it", file=sys.stderr)
         sys.exit(1)

--- a/agents/skills/typo-sweep/apply-fix.py
+++ b/agents/skills/typo-sweep/apply-fix.py
@@ -1,42 +1,96 @@
 #!/usr/bin/env python3
 """
-Apply a single typo fix to a file. Uses exact line match for safety.
-Usage: apply-fix.py <file> <line_num> <old_word> <new_word>
+Apply a single typo fix to a file, with two safety guards.
 
-The replacement is done on the specified line only, replacing whole-word
-matches of <old_word> with <new_word>. Preserves case style heuristically
-but accepts that we pass exact-case words already.
+Usage: apply-fix.py <file> <line_num> <old_word> <new_word> [expected_line]
+
+Replaces the first whole-word match of <old_word> with <new_word> on the
+target line. The fix is refused (loudly, exit 1) rather than applied wrongly
+when either guard trips:
+
+1. Content match (drift-safe). When <expected_line> is given — pass the verbatim
+   line text the scan saw (the part after `path:line:col:` in scan.sh output) —
+   the substitution only happens on a line whose content equals it. If line
+   <line_num> still matches, that line is used; otherwise the file is searched
+   for the (unique) line with that content. A line that has since changed or
+   been fixed upstream is skipped, never guessed at. Omit <expected_line> to
+   fall back to plain line-number addressing.
+
+2. Single-quote guard. A correction containing an apostrophe (don't, doesn't,
+   today's, ...) is refused when the match sits inside a single-quoted string
+   literal — the apostrophe would terminate the string (e.g. RSpec `it '...'`,
+   JS `it('...')`) and break the build. Comments and double-quoted strings are
+   safe and proceed normally.
+
+Exit codes: 0 applied · 1 skipped (drift / word absent / would break string) · 2 usage.
 """
 import sys
 import re
 from pathlib import Path
 
-if len(sys.argv) != 5:
-    print("Usage: apply-fix.py <file> <line_num> <old_word> <new_word>", file=sys.stderr)
+if len(sys.argv) not in (5, 6):
+    print("Usage: apply-fix.py <file> <line_num> <old_word> <new_word> [expected_line]", file=sys.stderr)
     sys.exit(2)
 
 path = Path(sys.argv[1])
 line_num = int(sys.argv[2])
 old = sys.argv[3]
 new = sys.argv[4]
+expected = sys.argv[5] if len(sys.argv) == 6 else None
 
 lines = path.read_text().splitlines(keepends=True)
-if line_num < 1 or line_num > len(lines):
-    print(f"Line {line_num} out of range for {path}", file=sys.stderr)
-    sys.exit(1)
-
-idx = line_num - 1
-line = lines[idx]
-
-# Word-boundary substitution. Use literal old, escape regex specials.
 pattern = re.compile(r'\b' + re.escape(old) + r'\b')
-match_count = len(pattern.findall(line))
-if match_count == 0:
-    print(f"No match for '{old}' on line {line_num} of {path}", file=sys.stderr)
-    print(f"Line: {line!r}", file=sys.stderr)
-    sys.exit(1)
 
-new_line = pattern.sub(new, line)
-lines[idx] = new_line
+
+def body(line):
+    return line.rstrip('\n').rstrip('\r')
+
+
+def has_word(line):
+    return pattern.search(line) is not None
+
+
+# --- Choose the target line index ---------------------------------------------
+if expected is None:
+    if line_num < 1 or line_num > len(lines):
+        print(f"Line {line_num} out of range for {path}", file=sys.stderr)
+        sys.exit(1)
+    idx = line_num - 1
+    if not has_word(lines[idx]):
+        print(f"SKIP(no-word) {path}:{line_num} '{old}' not on line: {lines[idx]!r}", file=sys.stderr)
+        sys.exit(1)
+else:
+    # Drift-safe: locate the line by its original content, not its number.
+    candidates = [i for i, l in enumerate(lines) if body(l) == expected and has_word(l)]
+    if 1 <= line_num <= len(lines) and (line_num - 1) in candidates:
+        idx = line_num - 1                       # fast path: line hasn't drifted
+    elif len(candidates) == 1:
+        idx = candidates[0]                      # moved, but unambiguous
+    elif not candidates:
+        print(f"SKIP(drift) {path}: original line for '{old}->{new}' not found "
+              f"(changed or already fixed upstream)", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print(f"SKIP(ambiguous) {path}: {len(candidates)} lines match the original "
+              f"content for '{old}->{new}'; refusing to guess", file=sys.stderr)
+        sys.exit(1)
+
+line = lines[idx]
+match = pattern.search(line)
+
+# --- Single-quote guard -------------------------------------------------------
+if "'" in new:
+    in_single = in_double = False
+    for ch in line[:match.start()]:
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+    if in_single:
+        print(f"SKIP(single-quote) {path}:{idx + 1} '{old}->{new}' sits inside a "
+              f"single-quoted string; apostrophe would break it", file=sys.stderr)
+        sys.exit(1)
+
+lines[idx] = pattern.sub(new, line, count=1)
 path.write_text(''.join(lines))
-print(f"OK {path}:{line_num} {old}->{new} ({match_count} replacement)")
+print(f"OK {path}:{idx + 1} {old}->{new}")

--- a/agents/skills/typo-sweep/test_apply_fix.py
+++ b/agents/skills/typo-sweep/test_apply_fix.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Tests for apply-fix.py. Self-contained (no pytest needed): `python3 test_apply_fix.py`.
+Each case pins a behavior of the contract, not the implementation.
+"""
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("apply-fix.py")
+failures = []
+
+
+def run(content, args):
+    """Write content to a tmp file, run apply-fix.py with args, return (rc, text_after, stderr)."""
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
+        f.write(content)
+        p = f.name
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), p, *map(str, args)],
+        capture_output=True, text=True,
+    )
+    after = Path(p).read_text()
+    Path(p).unlink()
+    return proc.returncode, after, proc.stderr
+
+
+def check(name, cond):
+    print(f"{'ok' if cond else 'FAIL'} - {name}")
+    if not cond:
+        failures.append(name)
+
+
+# 1. Plain apply (4-arg) on a comment line.
+rc, after, _ = run("    // ensure it doesnt exist\n", [1, "doesnt", "doesn't"])
+check("comment fix applies", rc == 0 and "doesn't exist" in after)
+
+# 2. Word absent on the target line -> skip, file untouched.
+rc, after, err = run("    // nothing to fix here\n", [1, "doesnt", "doesn't"])
+check("word-absent skips", rc == 1 and after == "    // nothing to fix here\n" and "no-word" in err)
+
+# 3. Single-quote guard refuses apostrophe into a single-quoted string.
+src = "  it('user dont care') {\n"
+rc, after, err = run(src, [1, "dont", "don't"])
+check("single-quote string refused", rc == 1 and after == src and "single-quote" in err)
+
+# 4. Same correction in a // comment is allowed.
+rc, after, _ = run("  // user dont care\n", [1, "dont", "don't"])
+check("apostrophe in comment allowed", rc == 0 and "don't care" in after)
+
+# 5. Apostrophe inside a double-quoted string is fine.
+rc, after, _ = run('  XCTAssert(x, "user dont care")\n', [1, "dont", "don't"])
+check("apostrophe in double-quoted string allowed", rc == 0 and "don't care" in after)
+
+# 6. Non-apostrophe correction inside single quotes still applies (guard is apostrophe-only).
+rc, after, _ = run("  label: 'a seperate thing',\n", [1, "seperate", "separate"])
+check("non-apostrophe fix in single quotes applies", rc == 0 and "separate thing" in after)
+
+# 7. Drift: expected content moved to a different line number -> found and applied.
+content = "header\nmoved\n    // ensure it doesnt exist\nfooter\n"
+rc, after, _ = run(content, [99, "doesnt", "doesn't", "    // ensure it doesnt exist"])
+check("drift content match applies at moved line", rc == 0 and "doesn't exist" in after)
+
+# 8. Drift: original line gone (already fixed upstream) -> skip.
+rc, after, err = run("    // ensure it doesn't exist\n", [1, "doesnt", "doesn't", "    // ensure it doesnt exist"])
+check("drift missing line skips", rc == 1 and "doesn't exist" in after and "drift" in err)
+
+# 9. Ambiguous: two identical original lines, line_num points to neither -> refuse.
+content = "    // x doesnt y\nmid\n    // x doesnt y\n"
+rc, after, err = run(content, [2, "doesnt", "doesn't", "    // x doesnt y"])
+check("ambiguous content refused", rc == 1 and after == content and "ambiguous" in err)
+
+# 10. Drift fast path: line_num correct and content matches -> applies there.
+content = "a\n    // ensure it doesnt exist\nb\n"
+rc, after, _ = run(content, [2, "doesnt", "doesn't", "    // ensure it doesnt exist"])
+check("drift fast path applies", rc == 0 and "doesn't exist" in after)
+
+print(f"\n{len(failures)} failure(s)" if failures else "\nall passed")
+sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Rationale

An a8c-wide `typo-sweep` run hit two failure modes that the apply step couldn't catch. This hardens `apply-fix.py` so the tool prevents both instead of relying on after-the-fact CI diagnosis.

- **Single-quote guard** — an apostrophe correction (`don't`, `today's`) inside a single-quoted string literal (RSpec `it '...'`, JS `it('...')`) terminates the string and breaks the build. Now refused; comments and double-quoted strings still proceed.
- **Drift-safe content match** — an optional 5th arg (the scan's matched line text) makes the fix land by content, so a drifted checkout can't cause a wrong-line edit; a line that changed or was already fixed upstream is skipped loudly.

## How to test

`python3 agents/skills/typo-sweep/test_apply_fix.py` — 10 cases pinning both guards, the drift fast path, and the ambiguity case.

---

*Posted by Claude (Opus 4.8) on behalf of @mokagio with approval.*
