### PR TITLE
Add Jellyfin backup and mount-gated launch scripts

### DIFF
--- a/scripts/jellyfin-backup
+++ b/scripts/jellyfin-backup
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Snapshot the Jellyfin server's config, metadata and database to a dated
+# directory, keeping the most recent JELLYFIN_BACKUP_KEEP snapshots.
+#
+# Jellyfin can empty an entire library when its media volume drops off the bus
+# (jellyfin/jellyfin#1714), and rebuilding costs days. Snapshots are the
+# mitigation the maintainers recommend, as there is no way to make Jellyfin
+# tolerate a temporarily missing library path.
+
+JELLYFIN_DATA_DIR="${JELLYFIN_DATA_DIR:-$HOME/Library/Application Support/jellyfin}"
+JELLYFIN_BACKUP_DIR="${JELLYFIN_BACKUP_DIR:-$HOME/Backups/jellyfin}"
+JELLYFIN_BACKUP_KEEP="${JELLYFIN_BACKUP_KEEP:-7}"
+
+# The SQLite files are excluded here and copied by snapshot_database instead:
+# rsync of a database being written to can capture a torn write.
+RSYNC_EXCLUDES=(
+  --exclude cache/
+  --exclude log/
+  --exclude transcodes/
+  --exclude 'data/*.db'
+  --exclude 'data/*.db-wal'
+  --exclude 'data/*.db-shm'
+)
+
+log() {
+  printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*"
+}
+
+copy_tree() {
+  local src=$1 dest=$2
+  mkdir -p "$dest"
+  rsync -a "${RSYNC_EXCLUDES[@]}" "$src/" "$dest/"
+}
+
+# `.backup` takes a consistent snapshot of a live database; `cp` does not.
+snapshot_database() {
+  local src=$1 dest=$2
+  [[ -f "$src" ]] || return 0
+  mkdir -p "$(dirname "$dest")"
+  sqlite3 "$src" ".backup '$dest'"
+}
+
+verify_database() {
+  local db=$1
+  [[ -f "$db" ]] || return 0
+  local result
+  result="$(sqlite3 "$db" 'PRAGMA integrity_check;' 2>&1)" || return 1
+  [[ "$result" == ok ]]
+}
+
+prune_snapshots() {
+  local dir=$1 keep=$2 snapshot index=0
+  [[ -d "$dir" ]] || return 0
+
+  # Snapshot names are ISO-8601-ish, so lexical order is chronological order.
+  while IFS= read -r snapshot; do
+    if (( index >= keep )); then
+      rm -rf "$snapshot"
+    fi
+    index=$(( index + 1 ))
+  done < <(find "$dir" -mindepth 1 -maxdepth 1 -type d -name '20*' | sort -r)
+}
+
+main() {
+  local stamp=${1:-$(date '+%Y-%m-%dT%H-%M-%S')}
+  local dest="$JELLYFIN_BACKUP_DIR/$stamp"
+
+  if [[ ! -d "$JELLYFIN_DATA_DIR" ]]; then
+    log "no Jellyfin data directory at $JELLYFIN_DATA_DIR"
+    return 1
+  fi
+
+  log "snapshotting $JELLYFIN_DATA_DIR -> $dest"
+  copy_tree "$JELLYFIN_DATA_DIR" "$dest"
+  snapshot_database "$JELLYFIN_DATA_DIR/data/jellyfin.db" "$dest/data/jellyfin.db"
+
+  if ! verify_database "$dest/data/jellyfin.db"; then
+    log "integrity check failed for $dest/data/jellyfin.db"
+    return 1
+  fi
+
+  prune_snapshots "$JELLYFIN_BACKUP_DIR" "$JELLYFIN_BACKUP_KEEP"
+  log "done, $(du -sh "$dest" | cut -f1) in $dest"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  main "$@"
+fi

--- a/scripts/jellyfin-gated-launch
+++ b/scripts/jellyfin-gated-launch
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Launch Jellyfin only once its media volume is mounted, and refuse to launch it
+# at all if the volume never turns up.
+#
+# Jellyfin has no setting to tolerate a temporarily missing library path. If it
+# scans while the volume is absent it can empty the library
+# (jellyfin/jellyfin#1714), and the "Clean up collections and playlists"
+# scheduled task deletes playlists outright.
+#
+# launchd's WatchPaths cannot do this job: mounting a volume fires no
+# file-modification event, so the poll below is the mechanism that actually
+# works.
+
+JELLYFIN_VOLUME="${JELLYFIN_VOLUME:-/Volumes/Extreme SSD}"
+JELLYFIN_SENTINEL="${JELLYFIN_SENTINEL:-Movies}"
+JELLYFIN_WAIT_TIMEOUT="${JELLYFIN_WAIT_TIMEOUT:-600}"
+JELLYFIN_POLL_INTERVAL="${JELLYFIN_POLL_INTERVAL:-2}"
+JELLYFIN_LAUNCH_CMD="${JELLYFIN_LAUNCH_CMD:-open -a Jellyfin}"
+
+log() {
+  printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*"
+}
+
+# Requires a non-empty sentinel directory rather than just the mount point:
+# macOS can leave an empty /Volumes/<name> behind after an unclean eject, and
+# Jellyfin treats an empty library folder exactly as it treats a missing one.
+volume_ready() {
+  local volume=$1 sentinel=$2
+  [[ -d "$volume/$sentinel" ]] || return 1
+  [[ -n "$(ls -A "$volume/$sentinel" 2>/dev/null)" ]]
+}
+
+wait_for_volume() {
+  local volume=$1 sentinel=$2 timeout=$3 interval=$4
+  local waited=0
+
+  while ! volume_ready "$volume" "$sentinel"; do
+    if (( waited >= timeout )); then
+      return 1
+    fi
+    sleep "$interval"
+    waited=$(( waited + interval ))
+  done
+}
+
+main() {
+  if ! wait_for_volume \
+    "$JELLYFIN_VOLUME" "$JELLYFIN_SENTINEL" \
+    "$JELLYFIN_WAIT_TIMEOUT" "$JELLYFIN_POLL_INTERVAL"; then
+    log "gave up after ${JELLYFIN_WAIT_TIMEOUT}s waiting for $JELLYFIN_VOLUME/$JELLYFIN_SENTINEL; not launching"
+    return 1
+  fi
+
+  log "$JELLYFIN_VOLUME is mounted; launching Jellyfin"
+  # shellcheck disable=SC2086 # the command is meant to word-split
+  $JELLYFIN_LAUNCH_CMD
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  main "$@"
+fi

--- a/test/jellyfin-backup.bats
+++ b/test/jellyfin-backup.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+# Tests for the copy, database-snapshot and pruning logic in
+# scripts/jellyfin-backup. Sources the script (which bails at the BASH_SOURCE
+# guard) to call the functions in isolation.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+  TMP="$(mktemp -d)"
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/scripts/jellyfin-backup"
+
+  SRC="$TMP/jellyfin"
+  mkdir -p "$SRC/config" "$SRC/data" "$SRC/metadata" "$SRC/cache" "$SRC/log" "$SRC/transcodes"
+  echo '<encoding/>' > "$SRC/config/encoding.xml"
+  echo poster > "$SRC/metadata/poster.jpg"
+  echo junk > "$SRC/cache/chunk"
+  echo junk > "$SRC/log/jellyfin.log"
+  echo junk > "$SRC/transcodes/tmp.ts"
+  sqlite3 "$SRC/data/jellyfin.db" 'CREATE TABLE items (id INTEGER); INSERT INTO items VALUES (42);'
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "Copy preserves config and metadata" {
+  copy_tree "$SRC" "$TMP/dest"
+  [[ -f "$TMP/dest/config/encoding.xml" ]]
+  [[ -f "$TMP/dest/metadata/poster.jpg" ]]
+}
+
+@test "Copy skips regenerable cache, log and transcode directories" {
+  copy_tree "$SRC" "$TMP/dest"
+  [[ ! -e "$TMP/dest/cache/chunk" ]]
+  [[ ! -e "$TMP/dest/log/jellyfin.log" ]]
+  [[ ! -e "$TMP/dest/transcodes/tmp.ts" ]]
+}
+
+@test "Copy skips the live database so it can be snapshotted separately" {
+  copy_tree "$SRC" "$TMP/dest"
+  [[ ! -e "$TMP/dest/data/jellyfin.db" ]]
+}
+
+@test "Database snapshot is a readable copy of the original" {
+  snapshot_database "$SRC/data/jellyfin.db" "$TMP/dest/data/jellyfin.db"
+  run sqlite3 "$TMP/dest/data/jellyfin.db" 'SELECT id FROM items;'
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == 42 ]]
+}
+
+@test "Database snapshot of a missing database is not an error" {
+  run snapshot_database "$SRC/data/absent.db" "$TMP/dest/data/absent.db"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "Verification passes on a healthy database" {
+  snapshot_database "$SRC/data/jellyfin.db" "$TMP/dest/data/jellyfin.db"
+  run verify_database "$TMP/dest/data/jellyfin.db"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "Verification fails on a corrupt database" {
+  mkdir -p "$TMP/dest/data"
+  echo 'this is not a database' > "$TMP/dest/data/jellyfin.db"
+  run verify_database "$TMP/dest/data/jellyfin.db"
+  [[ "$status" -ne 0 ]]
+}
+
+@test "Pruning keeps the newest snapshots and removes the rest" {
+  mkdir -p "$TMP/backups"/2026-07-0{1,2,3,4}T00-00-00
+  prune_snapshots "$TMP/backups" 2
+  [[ -d "$TMP/backups/2026-07-04T00-00-00" ]]
+  [[ -d "$TMP/backups/2026-07-03T00-00-00" ]]
+  [[ ! -d "$TMP/backups/2026-07-02T00-00-00" ]]
+  [[ ! -d "$TMP/backups/2026-07-01T00-00-00" ]]
+}
+
+@test "Pruning leaves unrelated directories alone" {
+  mkdir -p "$TMP/backups/2026-07-01T00-00-00" "$TMP/backups/notes"
+  prune_snapshots "$TMP/backups" 0
+  [[ ! -d "$TMP/backups/2026-07-01T00-00-00" ]]
+  [[ -d "$TMP/backups/notes" ]]
+}
+
+@test "Pruning an absent directory is not an error" {
+  run prune_snapshots "$TMP/absent" 3
+  [[ "$status" -eq 0 ]]
+}
+
+@test "A full run snapshots the database and prunes to the keep limit" {
+  JELLYFIN_DATA_DIR="$SRC"
+  JELLYFIN_BACKUP_DIR="$TMP/backups"
+  JELLYFIN_BACKUP_KEEP=1
+  mkdir -p "$TMP/backups/2026-01-01T00-00-00"
+
+  run main 2026-07-09T12-00-00
+  [[ "$status" -eq 0 ]]
+  [[ -f "$TMP/backups/2026-07-09T12-00-00/config/encoding.xml" ]]
+  [[ -f "$TMP/backups/2026-07-09T12-00-00/data/jellyfin.db" ]]
+  [[ ! -d "$TMP/backups/2026-01-01T00-00-00" ]]
+}

--- a/test/jellyfin-gated-launch.bats
+++ b/test/jellyfin-gated-launch.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+# Tests for the volume-readiness logic in scripts/jellyfin-gated-launch.
+# Sources the script (which bails at the BASH_SOURCE guard) to call the
+# functions in isolation.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+  TMP="$(mktemp -d)"
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/scripts/jellyfin-gated-launch"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "Volume is not ready when the mount point is absent" {
+  run volume_ready "$TMP/absent" Movies
+  [[ "$status" -eq 1 ]]
+}
+
+@test "Volume is not ready when the sentinel directory is absent" {
+  mkdir -p "$TMP/volume"
+  run volume_ready "$TMP/volume" Movies
+  [[ "$status" -eq 1 ]]
+}
+
+@test "Volume is not ready when the sentinel directory is empty" {
+  mkdir -p "$TMP/volume/Movies"
+  run volume_ready "$TMP/volume" Movies
+  [[ "$status" -eq 1 ]]
+}
+
+@test "Volume is ready when the sentinel directory has content" {
+  mkdir -p "$TMP/volume/Movies"
+  touch "$TMP/volume/Movies/a-film.mkv"
+  run volume_ready "$TMP/volume" Movies
+  [[ "$status" -eq 0 ]]
+}
+
+@test "A hidden entry alone counts as content" {
+  mkdir -p "$TMP/volume/Movies"
+  touch "$TMP/volume/Movies/.hidden"
+  run volume_ready "$TMP/volume" Movies
+  [[ "$status" -eq 0 ]]
+}
+
+@test "Waiting returns immediately when the volume is already mounted" {
+  mkdir -p "$TMP/volume/Movies"
+  touch "$TMP/volume/Movies/a-film.mkv"
+  run wait_for_volume "$TMP/volume" Movies 10 1
+  [[ "$status" -eq 0 ]]
+}
+
+@test "Waiting times out when the volume never appears" {
+  run wait_for_volume "$TMP/absent" Movies 1 1
+  [[ "$status" -eq 1 ]]
+}
+
+@test "Waiting times out rather than launching against an empty sentinel" {
+  mkdir -p "$TMP/volume/Movies"
+  run wait_for_volume "$TMP/volume" Movies 1 1
+  [[ "$status" -eq 1 ]]
+}
+
+@test "Main does not launch Jellyfin when the volume never appears" {
+  JELLYFIN_VOLUME="$TMP/absent"
+  JELLYFIN_SENTINEL=Movies
+  JELLYFIN_WAIT_TIMEOUT=1
+  JELLYFIN_POLL_INTERVAL=1
+  JELLYFIN_LAUNCH_CMD="touch $TMP/launched"
+
+  run main
+  [[ "$status" -eq 1 ]]
+  [[ ! -e "$TMP/launched" ]]
+  [[ "$output" == *"not launching"* ]]
+}
+
+@test "Main launches Jellyfin once the volume is mounted" {
+  mkdir -p "$TMP/volume/Movies"
+  touch "$TMP/volume/Movies/a-film.mkv"
+  JELLYFIN_VOLUME="$TMP/volume"
+  JELLYFIN_SENTINEL=Movies
+  JELLYFIN_WAIT_TIMEOUT=1
+  JELLYFIN_POLL_INTERVAL=1
+  JELLYFIN_LAUNCH_CMD="touch $TMP/launched"
+
+  run main
+  [[ "$status" -eq 0 ]]
+  [[ -e "$TMP/launched" ]]
+}


### PR DESCRIPTION
## Rationale

The Jellyfin server on my Mac keeps its library on an external SSD that intermittently drops off the USB bus. When Jellyfin scans while the volume is absent it can empty the library ([`jellyfin/jellyfin#1714`](https://github.com/jellyfin/jellyfin/issues/1714), open since 2019), and the "Clean up collections and playlists" scheduled task [deletes playlists outright](https://jellyfin.org/docs/general/server/tasks/). Jellyfin has no setting to tolerate a temporarily missing library path, so the fix has to live outside it.

`jellyfin-gated-launch` waits for the volume before starting the server, and refuses to start it at all if the volume never appears. `jellyfin-backup` snapshots config, metadata and the database — the mitigation the Jellyfin maintainers recommend for #1714.

## Intentional tradeoffs

- **Polling, not `launchd` `WatchPaths`.** Mounting a volume fires no file-modification event, so `WatchPaths` on `/Volumes/<name>` does not reliably trigger. Polling is what the Plex/Jellyfin communities actually run.
- **Readiness requires a non-empty sentinel directory,** not just the mount point. macOS can leave an empty `/Volumes/<name>` behind after an unclean eject, and Jellyfin treats an empty library folder exactly as it treats a missing one.
- **`sqlite3 .backup` instead of `rsync` for the database.** `jellyfin.db` is written to while the server runs; a plain file copy can capture a torn write.

## Gotchas

Both scripts are configured entirely through environment variables, so the machine-specific volume name lives in the LaunchAgent plist rather than in this repo.

## How to test

```
bats test/jellyfin-backup.bats test/jellyfin-gated-launch.bats
```

Both suites are hermetic — tmpdirs, a throwaway SQLite database, and an injected launch command, so nothing touches a real Jellyfin install.

---

*Posted by Claude Code (Opus 4.8) on behalf of @mokagio with approval.*